### PR TITLE
fix: Fix vscode FIFO path is broken

### DIFF
--- a/dbgee/src/debugger_terminal.rs
+++ b/dbgee/src/debugger_terminal.rs
@@ -231,7 +231,7 @@ fn build_attach_request_fifo_path() -> Option<String> {
     if !sock_name.ends_with(".sock") {
         return None;
     }
-    let mut path = format!("{}-for-", vscode_communication_path_prefix());
+    let mut path = format!("{}-debuggee-for-", vscode_communication_path_prefix());
     path.extend(sock_name[0..sock_name.len() - 5].chars().into_iter());
     Some(path)
 }


### PR DESCRIPTION
Fix the FIFO path for the VSCode attach request is broken.